### PR TITLE
Fix/canceling selection before replacement ends

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ We welcome contributions to google-maps-vector-engine! This guide will help you 
 
 ### Prerequisites
 
-- **Node.js 16+**
+- **Node.js 18+**
 - **npm or yarn**
 - **Git**
 - **TypeScript knowledge**

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 > **Render Mapbox Vector Tiles (PBF) on Google Maps with full interactivity.**
 
+☕ **Support this project:** [Buy me a coffee](https://buymeacoffee.com/medali.07) • [Ko-fi](https://ko-fi.com/medalihachicha)
+
 Google Maps doesn't natively support vector tiles (PBF format) - only raster tiles (PNG/JPEG). This library enables vector tile rendering with native-like performance and full interactivity impossible with static raster tiles.
 
 ## ⚡ Quick Start

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "google-maps-vector-engine",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "High-performance TypeScript engine for rendering Mapbox Vector Tiles (MVT/PBF) on Google Maps with advanced features including fast feature lookups, interactive selections, dynamic styling, and optimized rendering.",
   "main": "dist/index.js",
   "module": "dist/esm/index.js",
@@ -79,7 +79,16 @@
     "node": ">=16.0.0"
   },
   "sideEffects": false,
-  "funding": "https://ko-fi.com/medalihachicha",
+  "funding": [
+    {
+      "type": "buy-me-a-coffee",
+      "url": "https://buymeacoffee.com/medali.07"
+    },
+    {
+      "type": "ko-fi",
+      "url": "https://ko-fi.com/medalihachicha"
+    }
+  ],
   "publishConfig": {
     "access": "public"
   }

--- a/tests/unit/MVTSource.test.ts
+++ b/tests/unit/MVTSource.test.ts
@@ -1,0 +1,245 @@
+// Mock the mapbox-vector-tile module to avoid ESM issues
+jest.mock('@mapbox/vector-tile', () => ({
+  VectorTile: jest.fn(),
+  VectorTileFeature: jest.fn()
+}));
+
+jest.mock('pbf', () => jest.fn());
+
+import { MVTSource } from '../../src/MVTSource';
+import { MVTFeature } from '../../src/MVTFeature';
+
+// Mock Google Maps types
+const mockMap = {
+  overlayMapTypes: {
+    getArray: jest.fn(() => []),
+    removeAt: jest.fn(),
+    push: jest.fn(),
+    insertAt: jest.fn()
+  },
+  data: {
+    addListener: jest.fn(() => ({ remove: jest.fn() })),
+    remove: jest.fn()
+  },
+  addListener: jest.fn(() => ({ remove: jest.fn() }))
+} as any;
+
+// Mock console methods to avoid noise in tests
+global.console = {
+  ...console,
+  log: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn()
+};
+
+describe('MVTSource Race Condition Fix', () => {
+  let mvtSource: MVTSource;
+  let mockGetReplacementFeature: jest.Mock;
+  let mockFeatureSelectionCallback: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    mockGetReplacementFeature = jest.fn();
+    mockFeatureSelectionCallback = jest.fn();
+
+    mvtSource = new MVTSource(mockMap, {
+      url: 'https://example.com/{z}/{x}/{y}.pbf',
+      getReplacementFeature: mockGetReplacementFeature,
+      featureSelectionCallback: mockFeatureSelectionCallback
+    });
+  });
+
+  afterEach(() => {
+    if (mvtSource) {
+      mvtSource.dispose();
+    }
+  });
+
+  test('should cancel pending replacement request when feature is deselected', async () => {
+    // Mock a slow async replacement function
+    const slowReplacementPromise = new Promise((resolve) => {
+      setTimeout(() => {
+        resolve({
+          type: 'Feature',
+          id: 'test-feature',
+          properties: { name: 'Test Feature' },
+          geometry: { type: 'Point', coordinates: [0, 0] }
+        });
+      }, 100);
+    });
+
+    mockGetReplacementFeature.mockReturnValue(slowReplacementPromise);
+
+    // Create a mock feature
+    const mockVectorFeature = {
+      type: 1,
+      properties: { id: 'test-feature' },
+      loadGeometry: jest.fn(),
+      bbox: jest.fn(),
+      toGeoJSON: jest.fn()
+    };
+
+    const mockTileContext = {
+      id: 'tile-1',
+      canvas: document.createElement('canvas'),
+      context: document.createElement('canvas').getContext('2d'),
+      zoom: 10,
+      x: 1,
+      y: 1,
+      tileSize: 256,
+      geoTransform: jest.fn()
+    };
+
+    // Simulate feature being registered and selected
+    const feature = new MVTFeature({
+      mVTSource: mvtSource,
+      vectorTileFeature: mockVectorFeature,
+      tileContext: mockTileContext,
+      style: { fillColor: '#000000' },
+      selected: false,
+      featureId: 'test-feature'
+    });
+
+    // Access private methods for testing
+    const selectFeature = (mvtSource as any)._selectFeature.bind(mvtSource);
+    const deselectFeature = (mvtSource as any)._deselectFeature.bind(mvtSource);
+    
+    // Register the feature in the index
+    (mvtSource as any)._featureIndex.set('test-feature', feature);
+
+    // Select the feature (this should start the replacement request)
+    selectFeature('test-feature');
+
+    // Verify that the replacement function was called
+    expect(mockGetReplacementFeature).toHaveBeenCalledTimes(1);
+
+    // Immediately deselect the feature before the async call completes
+    deselectFeature('test-feature');
+
+    // Wait for the async operation to complete
+    await new Promise(resolve => setTimeout(resolve, 150));
+
+    // The callback should only be called for the deselection, not for the completed replacement
+    expect(mockFeatureSelectionCallback).toHaveBeenCalledTimes(1);
+    expect(mockFeatureSelectionCallback).toHaveBeenCalledWith('test-feature', expect.any(Object), false);
+
+    // Verify no pending requests remain
+    const pendingRequests = (mvtSource as any)._pendingReplacementRequests;
+    expect(pendingRequests.size).toBe(0);
+  });
+
+  test('should handle rapid selection/deselection gracefully', async () => {
+    let callCount = 0;
+    mockGetReplacementFeature.mockImplementation(() => {
+      callCount++;
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            type: 'Feature',
+            id: 'test-feature',
+            properties: { name: 'Test Feature' },
+            geometry: { type: 'Point', coordinates: [0, 0] }
+          });
+        }, 50);
+      });
+    });
+
+    // Create mock feature setup
+    const mockVectorFeature = {
+      type: 1,
+      properties: { id: 'test-feature' },
+      loadGeometry: jest.fn(),
+      bbox: jest.fn(),
+      toGeoJSON: jest.fn()
+    };
+
+    const mockTileContext = {
+      id: 'tile-1',
+      canvas: document.createElement('canvas'),
+      context: document.createElement('canvas').getContext('2d'),
+      zoom: 10,
+      x: 1,
+      y: 1,
+      tileSize: 256,
+      geoTransform: jest.fn()
+    };
+
+    const feature = new MVTFeature({
+      mVTSource: mvtSource,
+      vectorTileFeature: mockVectorFeature,
+      tileContext: mockTileContext,
+      style: { fillColor: '#000000' },
+      selected: false,
+      featureId: 'test-feature'
+    });
+
+    const selectFeature = (mvtSource as any)._selectFeature.bind(mvtSource);
+    const deselectFeature = (mvtSource as any)._deselectFeature.bind(mvtSource);
+    (mvtSource as any)._featureIndex.set('test-feature', feature);
+
+    // Select the feature
+    selectFeature('test-feature');
+    
+    // Quickly deselect and select again 
+    deselectFeature('test-feature');
+    selectFeature('test-feature');
+
+    // Wait for any async operations
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Should handle this gracefully without errors
+    expect(callCount).toBeGreaterThan(0);
+    expect(mockFeatureSelectionCallback).toHaveBeenCalled();
+  });
+
+  test('should clean up all pending requests on dispose', async () => {
+    const neverResolvingPromise = new Promise(() => {}); // Never resolves
+    mockGetReplacementFeature.mockReturnValue(neverResolvingPromise);
+
+    // Create mock feature
+    const mockVectorFeature = {
+      type: 1,
+      properties: { id: 'test-feature' },
+      loadGeometry: jest.fn(),
+      bbox: jest.fn(),
+      toGeoJSON: jest.fn()
+    };
+
+    const mockTileContext = {
+      id: 'tile-1',
+      canvas: document.createElement('canvas'),
+      context: document.createElement('canvas').getContext('2d'),
+      zoom: 10,
+      x: 1,
+      y: 1,
+      tileSize: 256,
+      geoTransform: jest.fn()
+    };
+
+    const feature = new MVTFeature({
+      mVTSource: mvtSource,
+      vectorTileFeature: mockVectorFeature,
+      tileContext: mockTileContext,
+      style: { fillColor: '#000000' },
+      selected: false,
+      featureId: 'test-feature'
+    });
+
+    const selectFeature = (mvtSource as any)._selectFeature.bind(mvtSource);
+    (mvtSource as any)._featureIndex.set('test-feature', feature);
+
+    // Select feature to create a pending request
+    selectFeature('test-feature');
+
+    // Verify there's a pending request
+    const pendingRequests = (mvtSource as any)._pendingReplacementRequests;
+    expect(pendingRequests.size).toBe(1);
+
+    // Dispose the source
+    mvtSource.dispose();
+
+    // Verify all pending requests are cleaned up
+    expect(pendingRequests.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem
When users rapidly select and deselect features, the async `getReplacementFeature` API call could complete after deselection, causing unwanted feature replacements to be applied even though the user had already moved on.

## Solution
- Added **AbortController** to track and cancel pending replacement requests  
- Enhanced deselection logic to immediately cancel ongoing API calls  
- Added **selection state validation** before applying replacement results  
- Prevented **duplicate requests** for the same feature  

## Impact
✅ Eliminates unwanted feature selections after deselection  
✅ Improves UX responsiveness for rapid user interactions  
✅ No performance overhead or breaking changes  
✅ Comprehensive test coverage added  
